### PR TITLE
fix for issue #5

### DIFF
--- a/lib/minimap-color-highlight-view.coffee
+++ b/lib/minimap-color-highlight-view.coffee
@@ -17,7 +17,7 @@ module.exports = (minimapPkg, colorHighlight) ->
       @observeConfig()
 
     destroy: ->
-      @subscription.off()
+      @subscription.dispose()
       @destroyDecorations()
       @minimapView?.find('.atom-color-highlight').remove()
 


### PR DESCRIPTION
Fix for Disposable.off is deprecated https://github.com/abe33/minimap-color-highlight/issues/5